### PR TITLE
Add README to https://pypi.org/project/minesweeper/

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+long_description = file: README.md
+long_description_content_type = text/markdown


### PR DESCRIPTION
Currently, the page on PyPI is empty: https://pypi.org/project/minesweeper/

With the suggested change, it could look like this:

* https://pypi.org/project/propy3/
* https://github.com/MartinThoma/propy3/blob/master/setup.cfg

As you can see in the propy3 example, you could move all metadata to setup.cfg. This would make the setup.py slimmer. setuptools.setup will pick it up automatically.